### PR TITLE
Prevent cross-origin content from tainting the canvas when extracted from the video element

### DIFF
--- a/project/src/render/capture.js
+++ b/project/src/render/capture.js
@@ -8,6 +8,7 @@ const capture = (video, frames, callback) => {
   canvas.height = video.height;
   const context = canvas.getContext('2d');
   const videoElem = document.createElement('video');
+  videoElem.crossOrigin = "anonymous";
   videoElem.src = video.source;
 
   const queue = frames.slice();


### PR DESCRIPTION
https://github.com/xyonix/vannot/issues/17